### PR TITLE
Seastar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ be tightly coupled to libraries like `boost::asio`.) If you're writing server co
 use `cxx-async`, but you will need to ensure that both the Rust and C++ sides run separate I/O
 executors.
 
-`cxx-async` aims for compatibility with popular C++ coroutine support libraries. Right now, both
-the lightweight [`cppcoro`](https://github.com/lewissbaker/cppcoro) and the more comprehensive
-[Folly](https://github.com/facebook/folly/) are supported. Pull requests are welcome to support
+`cxx-async` aims for compatibility with popular C++ coroutine support libraries. The ones supported right now are the lightweight [`cppcoro`](https://github.com/lewissbaker/cppcoro), the more comprehensive
+[Folly](https://github.com/facebook/folly/) and Scylla's [Seastar](https://github.com/scylladb/seastar). Pull requests are welcome to support
 others.
 
 ## Quick tutorial

--- a/cxx-async/build.rs
+++ b/cxx-async/build.rs
@@ -16,7 +16,7 @@ fn main() {
     }
 
     drop(fs::create_dir_all(&dest_include_path));
-    for header in &["cxx_async.h", "cxx_async_cppcoro.h", "cxx_async_folly.h"] {
+    for header in &["cxx_async.h", "cxx_async_cppcoro.h", "cxx_async_folly.h", "cxx_async_seastar.h"] {
         drop(fs::copy(
             Path::join(&src_include_path, header),
             Path::join(&dest_include_path, header),

--- a/cxx-async/build.rs
+++ b/cxx-async/build.rs
@@ -29,6 +29,7 @@ fn main() {
     println!("cargo:rerun-if-changed=include/rust/cxx_async.h");
     println!("cargo:rerun-if-changed=include/rust/cxx_async_cppcoro.h");
     println!("cargo:rerun-if-changed=include/rust/cxx_async_folly.h");
+    println!("cargo:rerun-if-changed=include/rust/cxx_async_seastar.h");
 
     println!("cargo:rustc-cfg=built_with_cargo");
 
@@ -37,6 +38,7 @@ fn main() {
         .files(&vec!["src/cxx_async.cpp"])
         .flag_if_supported("-std=c++20")
         .flag_if_supported("-fcoroutines-ts")
+        .flag_if_supported("-fcoroutines")
         .include("include")
         .compile("cxx-async");
 }

--- a/cxx-async/include/rust/cxx_async_seastar.h
+++ b/cxx-async/include/rust/cxx_async_seastar.h
@@ -29,6 +29,9 @@
 #include <seastar/core/make_task.hh>
 #include "rust/cxx_async.h"
 
+namespace rust {
+namespace async {
+
 template<typename... T>
 struct cxx_awaiter {
     seastar::future<T...> _future;
@@ -109,9 +112,6 @@ public:
 
     void await_resume() { _future.get(); }
 };
-
-namespace rust {
-namespace async {
 
 template<typename T, typename Future>
 class AwaitTransformer<

--- a/cxx-async/include/rust/cxx_async_seastar.h
+++ b/cxx-async/include/rust/cxx_async_seastar.h
@@ -122,7 +122,7 @@ class AwaitTransformer<
 
  public:
   static auto await_transform(
-      RustPromiseBase<Future>& promise,
+      [[maybe_unused]] RustPromiseBase<Future>& promise,
       seastar::future<T>&& future) noexcept {
     return cxx_awaiter<T>(std::move(future));
   }

--- a/cxx-async/include/rust/cxx_async_seastar.h
+++ b/cxx-async/include/rust/cxx_async_seastar.h
@@ -16,7 +16,7 @@
  * under the License.
  */
 /*
- * Copyright (C) 2015 Cloudius Systems, Ltd.
+ * Copyright (C) 2023 ScyllaDB, Ltd.
  */
 
 // cxx-async/include/rust/cxx_async_seastar.h
@@ -25,9 +25,9 @@
 #define RUST_CXX_ASYNC_SEASTAR_H
 
 #include <seastar/core/future.hh>
-#include <seastar/core/std-coroutine.hh>
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/make_task.hh>
-#include "rust/cxx_async.h"
+#include "cxx_async.h"
 
 namespace rust {
 namespace async {
@@ -44,7 +44,7 @@ public:
     bool await_ready() const noexcept { return _future.available(); }
 
     template<typename U>
-    void await_suspend(SEASTAR_INTERNAL_COROUTINE_NAMESPACE::coroutine_handle<U> hndl) noexcept {
+    void await_suspend(std::coroutine_handle<U> hndl) noexcept {
         seastar::task* t = seastar::make_task([hndl = std::move(hndl)] {
             hndl.resume();
         });
@@ -71,7 +71,7 @@ public:
     bool await_ready() const noexcept { return _future.available(); }
 
     template<typename U>
-    void await_suspend(SEASTAR_INTERNAL_COROUTINE_NAMESPACE::coroutine_handle<U> hndl) noexcept {
+    void await_suspend(std::coroutine_handle<U> hndl) noexcept {
         seastar::task* t = seastar::make_task([hndl = std::move(hndl)] {
             hndl.resume();
         });
@@ -98,7 +98,7 @@ public:
     bool await_ready() const noexcept { return _future.available(); }
 
     template<typename U>
-    void await_suspend(SEASTAR_INTERNAL_COROUTINE_NAMESPACE::coroutine_handle<U> hndl) noexcept {
+    void await_suspend(std::coroutine_handle<U> hndl) noexcept {
         seastar::task* t = seastar::make_task([hndl = std::move(hndl)] {
             hndl.resume();
         });

--- a/cxx-async/include/rust/cxx_async_seastar.h
+++ b/cxx-async/include/rust/cxx_async_seastar.h
@@ -1,0 +1,134 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2015 Cloudius Systems, Ltd.
+ */
+
+// cxx-async/include/rust/cxx_async_seastar.h
+
+#ifndef RUST_CXX_ASYNC_SEASTAR_H
+#define RUST_CXX_ASYNC_SEASTAR_H
+
+#include <seastar/core/future.hh>
+#include <seastar/core/std-coroutine.hh>
+#include <seastar/core/make_task.hh>
+#include "rust/cxx_async.h"
+
+template<typename... T>
+struct cxx_awaiter {
+    seastar::future<T...> _future;
+public:
+    explicit cxx_awaiter(seastar::future<T...>&& f) noexcept : _future(std::move(f)) { }
+
+    cxx_awaiter(const cxx_awaiter&) = delete;
+    cxx_awaiter(cxx_awaiter&&) = delete;
+
+    bool await_ready() const noexcept { return _future.available(); }
+
+    template<typename U>
+    void await_suspend(SEASTAR_INTERNAL_COROUTINE_NAMESPACE::coroutine_handle<U> hndl) noexcept {
+        seastar::task* t = seastar::make_task([hndl = std::move(hndl)] {
+            hndl.resume();
+        });
+        
+        if (!_future.available()) {
+            _future.set_coroutine(*t);
+        } else {
+            schedule(t);
+        }
+    }
+
+    std::tuple<T...> await_resume() { return _future.get(); }
+};
+
+template<typename T>
+struct cxx_awaiter<T> {
+    seastar::future<T> _future;
+public:
+    explicit cxx_awaiter(seastar::future<T>&& f) noexcept : _future(std::move(f)) { }
+
+    cxx_awaiter(const cxx_awaiter&) = delete;
+    cxx_awaiter(cxx_awaiter&&) = delete;
+
+    bool await_ready() const noexcept { return _future.available(); }
+
+    template<typename U>
+    void await_suspend(SEASTAR_INTERNAL_COROUTINE_NAMESPACE::coroutine_handle<U> hndl) noexcept {
+        seastar::task* t = seastar::make_task([hndl = std::move(hndl)] {
+            hndl.resume();
+        });
+        
+        if (!_future.available()) {
+            _future.set_coroutine(*t);
+        } else {
+            schedule(t);
+        }
+    }
+
+    T await_resume() { return _future.get0(); }
+};
+
+template<>
+struct cxx_awaiter<> {
+    seastar::future<> _future;
+public:
+    explicit cxx_awaiter(seastar::future<>&& f) noexcept : _future(std::move(f)) { }
+
+    cxx_awaiter(const cxx_awaiter&) = delete;
+    cxx_awaiter(cxx_awaiter&&) = delete;
+
+    bool await_ready() const noexcept { return _future.available(); }
+
+    template<typename U>
+    void await_suspend(SEASTAR_INTERNAL_COROUTINE_NAMESPACE::coroutine_handle<U> hndl) noexcept {
+        seastar::task* t = seastar::make_task([hndl = std::move(hndl)] {
+            hndl.resume();
+        });
+        
+        if (!_future.available()) {
+            _future.set_coroutine(*t);
+        } else {
+            schedule(t);
+        }
+    }
+
+    void await_resume() { _future.get(); }
+};
+
+namespace rust {
+namespace async {
+
+template<typename T, typename Future>
+class AwaitTransformer<
+    seastar::future<T>,
+    Future,
+    void> {
+  AwaitTransformer() = delete;
+
+ public:
+  static auto await_transform(
+      RustPromiseBase<Future>& promise,
+      seastar::future<T>&& future) noexcept {
+    return cxx_awaiter<T>(std::move(future));
+  }
+};
+
+} // namespace async
+} // namespace rust
+
+#endif // RUST_CXX_ASYNC_SEASTAR_H


### PR DESCRIPTION
It's now possible to `co_await` a `seastar::future` from within `cxx-async`'s coroutines thanks to the added `cxx_awaiter`.